### PR TITLE
Placeholder Output Fix

### DIFF
--- a/gui_menus/kits.yml
+++ b/gui_menus/kits.yml
@@ -42,7 +42,7 @@ items:
         available:
           type: string equals ignorecase
           input: '%essentials_kit_is_available_example%'
-          output: 'no'
+          output: '&cOFF'
     display_name: ' '
     lore:
     - "&8• &bKit: &7Example"
@@ -66,7 +66,7 @@ items:
         available:
           type: string equals ignorecase
           input: '%essentials_kit_is_available_example%'
-          output: 'yes'
+          output: '&aON'
     display_name: ' '
     lore:
     - "&8• &bKit: &7Example"


### PR DESCRIPTION
If you do `/papi bparse username %essentials_kit_is_available_kitname%` it shows `&aON` or `&cOFF`, not `yes` nor `no`.